### PR TITLE
Keep speed limit

### DIFF
--- a/ros/src/waypoint_loader/waypoint_loader.py
+++ b/ros/src/waypoint_loader/waypoint_loader.py
@@ -54,21 +54,6 @@ class WaypointLoader(object):
                 p.twist.twist.linear.x = float(self.velocity)
 
                 waypoints.append(p)
-        return self.decelerate(waypoints)
-
-    def distance(self, p1, p2):
-        x, y, z = p1.x - p2.x, p1.y - p2.y, p1.z - p2.z
-        return math.sqrt(x*x + y*y + z*z)
-
-    def decelerate(self, waypoints):
-        last = waypoints[-1]
-        last.twist.twist.linear.x = 0.
-        for wp in waypoints[:-1][::-1]:
-            dist = self.distance(wp.pose.pose.position, last.pose.pose.position)
-            vel = math.sqrt(2 * MAX_DECEL * dist)
-            if vel < 1.:
-                vel = 0.
-            wp.twist.twist.linear.x = min(vel, wp.twist.twist.linear.x)
         return waypoints
 
     def publish(self, waypoints):


### PR DESCRIPTION
resolves #1 

Makes sure that the calculated velocities in waypoints provided to
the control subsystem is within the speed limit. Although this error
never should happen, this is not considered to be a fatal failure,
and it's handled by simply setting the speed within the limit and log
the error.

This change relies on all base_waypoints having the speed set to a
constant speed_limit when loaded. There was however some code
applying initial acceleration on the vehicle to the base_waypoints,
which makes no sense so it was removed. Such calculations will later
on be added on the final_waypoints. But for now, all
final_waypoints are set to the speed limit and the acceleration is
instead solely handled by the throttle PID controller.