### PR TITLE
Improve deceleration for traffic lights

### DIFF
--- a/ros/src/styx_msgs/msg/Waypoint.msg
+++ b/ros/src/styx_msgs/msg/Waypoint.msg
@@ -1,2 +1,3 @@
 geometry_msgs/PoseStamped pose
 geometry_msgs/TwistStamped twist
+float64 acceleration

--- a/ros/src/waypoint_updater/speed_calculator.py
+++ b/ros/src/waypoint_updater/speed_calculator.py
@@ -17,11 +17,10 @@ class SpeedCalculator(object):
                               target_acceleration, current_accleration,
                               acceleration_limit, jerk_limit)
         else:
-            # No acceleration. Current speed will be returned regardless of distance.
-            self.distance_speed_lut = [current_speed]
-
-        # The list of distances represented in the LUT
-        self.distances = [i * self.delta_d for i in range(len(self.distance_speed_lut))]
+            # No acceleration. Current speed/acceleration will be returned regardless of distance.
+            self.distances = [0.0]
+            self.velocities = [current_speed]
+            self.accelerations = [current_accleration]
 
     def __accelerate(self, target_speed, current_speed,
                      target_acceleration, current_accleration,
@@ -29,48 +28,32 @@ class SpeedCalculator(object):
         # Calculate the velocity at each time-step when applying acceleration and jerk according to their max limits.
         # Instead of continuously calculate when the jerk must change sign such that the acceleration can be reduced to
         # zero at target speed, the iteration is started from both ends to find the speed overlap in the middle.
-        v0 = current_speed
-        a0 = current_accleration
-        v1 = target_speed
-        a1 = target_acceleration
-        j0 = jerk_limit
-        j1 = -jerk_limit
-        delta_t = 0.001
+        delta_t = 0.01
+        vs_current = [current_speed]
+        vs_target = [target_speed]
+        as_current = [current_accleration]
+        as_target = [target_acceleration]
 
-        velocity_from_start_time = []
-        velocity_from_end_time = []
+        while vs_current[-1] < vs_target[-1]:
+            vs_current.append(vs_current[-1] + as_current[-1] * delta_t)
+            vs_target.append(vs_target[-1] - as_target[-1] * delta_t)
+            as_current.append(min(acceleration_limit, as_current[-1] + jerk_limit * delta_t))
+            as_target.append(min(acceleration_limit, as_target[-1] + jerk_limit * delta_t))
 
-        while v1 > v0:
-            velocity_from_start_time.append(v0)
-            velocity_from_end_time.append(v1)
-            v0 += a0 * delta_t
-            v1 -= a1 * delta_t
-            a0 = min(acceleration_limit, a0 + j0 * delta_t)
-            a1 = min(acceleration_limit, a1 - j1 * delta_t)
+        # Calculate the middle time-step
+        middle_delta_t = (vs_target[-1] - vs_current[-1]) / as_current[-1]
+        delta_ts = [delta_t] * len(vs_current) + [middle_delta_t] + [delta_t] * len(vs_target)
 
-        # Calculate if the approximation is better with or without the middle point.
-        if (v0 - v1) < (a0 / 2.0):
-            velocity_from_start_time.append((v0 + v1) / 2.0)
-
-        # Concatenate the both lists into one common list from the start.
-        velocity_from_start_time += reversed(velocity_from_end_time)
+        # Concatenate the list starting from current with the reversed one starting from target.
+        self.velocities = vs_current + vs_target[::-1]
+        self.accelerations = as_current + as_target[::-1]
 
         # Calculate the distance at each time-step.
-        distance_from_start_time = []
+        self.distances = []
         d = 0.0
-        for v in velocity_from_start_time:
+        for delta_t, v in zip(delta_ts, self.velocities):
             d += v * delta_t
-            distance_from_start_time.append(d)
-
-        # Calculate a look-up table for the velocity at a given distance.
-        self.distance_speed_lut = []
-        d = 0.0
-        for i, d1 in enumerate(distance_from_start_time):
-            while d <= d1:
-                self.distance_speed_lut.append(velocity_from_start_time[i])
-                d += self.delta_d
-        # Make sure target velocity not is omitted (due to resolution of delta_d)
-        self.distance_speed_lut.append(velocity_from_start_time[-1])
+            self.distances.append(d)
 
     def __decelerate(self, target_speed, current_speed,
                      target_acceleration, current_accleration,
@@ -79,7 +62,12 @@ class SpeedCalculator(object):
         self.__accelerate(target_speed=current_speed, current_speed=target_speed,
                           target_acceleration=current_accleration, current_accleration=target_acceleration,
                           acceleration_limit=acceleration_limit, jerk_limit=jerk_limit)
-        self.distance_speed_lut.reverse()
+        self.velocities.reverse()
+        self.accelerations.reverse()
+        self.distances = [self.distances[-1] - distance for distance in self.distances[::-1]]
 
     def get_speed_at_distance(self, distance):
-        return np.interp(distance, self.distances, self.distance_speed_lut)
+        return np.interp(distance, self.distances, self.velocities)
+
+    def get_acceleration_at_distance(self, distance):
+        return np.interp(distance, self.distances, self.accelerations)

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -146,6 +146,7 @@ class WaypointCalculator(object):
             self.preceding_waypoint = Waypoint()
             self.preceding_waypoint.pose.pose = pose_msg.pose
             self.preceding_waypoint.twist.twist = velocity_msg.twist
+            self.preceding_waypoint.acceleration = 0.0
         elif self.previous_first_idx != first_idx:
             # Copy the preceding waypoint before updating the waypoint list.
             self.preceding_waypoint = self.waypoints[first_idx - self.previous_first_idx - 1]
@@ -164,13 +165,16 @@ class WaypointCalculator(object):
 
         # Base the acceleration on the velocity from preceding waypoint.
         current_speed = get_waypoint_velocity(self.preceding_waypoint)
+        current_acceleration = self.preceding_waypoint.acceleration
         speed_calc = SpeedCalculator(target_speed=self.max_velocity, current_speed=current_speed,
-                                     target_acceleration=0.0, current_accleration=0.0,
+                                     target_acceleration=0.0, current_accleration=current_acceleration,
                                      acceleration_limit=10.0, jerk_limit=10.0)
         distances = self.__calc_distances(self.preceding_waypoint)
         for idx in range(len(self.waypoints)):
             speed = speed_calc.get_speed_at_distance(distances[idx])
             set_waypoint_velocity(self.waypoints, idx, speed)
+            acceleration = speed_calc.get_acceleration_at_distance(distances[idx])
+            self.waypoints[idx].acceleration = acceleration
 
     def __calc_distances(self, preceding_waypoint):
         """Calculates the distances from the preceding waypoint to each of the waypoints in the path.


### PR DESCRIPTION
Resolves #8 

- Calculates the velocities at waypoints to decelerate according to a given jerk and acceleration limits. 
- If it's not possible to decelerate in time for a traffic-light, then the vehicle will continue without even trying to brake. This is to handle the case when the traffic-light change state from green just as the vehicle pass through.
- Tries to keep the jerk low, but may increase it up to 10 m/s^3 when necessary to be able to brake in time for traffic-lights.
- Add acceleration to each waypoint. Currently this is only used to correct the acceleration calculation in waypoint-updater, but it might be useful for the control subsystem as well.

One bug in this calculation is that the jerk may exceed its limit when the car is not keeping the speed-limit or, even worse, is accelerating prior to the deceleration. Maybe I'll fix this later. One naive solution is to detect if this happens and then step backwards and attempt to brake from each waypoint with it's given input acceleration, until finding a waypoint where this succeeds.