### PR TITLE
Bugfix for TL detector initialization

### DIFF
--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -20,6 +20,7 @@ class TLDetector(object):
 
         self.pose = None
         self.waypoints = None
+        self.wp_search = None
         self.camera_image = None
         self.lights = []
 


### PR DESCRIPTION
The program crashes when first pose topic arrives before the base
waypoints topic, ending up with an unknown wp_search member. The fix
is to initialize wp_search to None.