### PR TITLE
Prepare controller tuning

### DIFF
--- a/ros/launch/controller_tuning.launch
+++ b/ros/launch/controller_tuning.launch
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<launch>
+    <!-- Simulator Bridge -->
+    <include file="$(find styx)/launch/server.launch" />
+
+    <!--DBW Node -->
+    <include file="$(find twist_controller)/launch/controller_tuning.launch"/>
+
+    <!--Waypoint Loader -->
+    <include file="$(find waypoint_loader)/launch/waypoint_loader.launch"/>
+
+    <!--Waypoint Follower Node -->
+    <include file="$(find waypoint_follower)/launch/pure_pursuit.launch"/>
+
+    <!--Waypoint Updater Node -->
+    <include file="$(find waypoint_updater)/launch/controller_tuning.launch"/>
+
+    <!--Traffic Light Locations and Camera Config -->
+    <param name="traffic_light_config" textfile="$(find tl_detector)/sim_traffic_light_config.yaml" />
+</launch>

--- a/ros/src/twist_controller/launch/controller_tuning.launch
+++ b/ros/src/twist_controller/launch/controller_tuning.launch
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<launch>
+    <node pkg="twist_controller" type="dbw_node.py" name="dbw_node" output="screen">
+        <param name="vehicle_mass" value="1080." />
+        <param name="fuel_capacity" value="0." />
+        <param name="brake_deadband" value=".2" />
+        <param name="decel_limit" value="-5." />
+        <param name="accel_limit" value="1." />
+        <param name="wheel_radius" value="0.335" />
+        <param name="wheel_base" value="3" />
+        <param name="steer_ratio" value="14.8" />
+        <param name="max_lat_accel" value="3." />
+        <param name="max_steer_angle" value="8." />
+        <param name="tuning_active" type="bool" value="true" />
+    </node>
+</launch>

--- a/ros/src/twist_controller/pid.py
+++ b/ros/src/twist_controller/pid.py
@@ -5,23 +5,25 @@ MAX_NUM = float('inf')
 
 class PID(object):
     def __init__(self, kp, ki, kd, mn=MIN_NUM, mx=MAX_NUM):
-        self.kp = kp
-        self.ki = ki
-        self.kd = kd
+        self.coeffs = [kp, ki, kd]
         self.min = mn
         self.max = mx
 
-        self.int_val = self.last_error = 0.
+        self.reset()
 
     def reset(self):
+        self.last_error = None
         self.int_val = 0.0
 
     def step(self, error, sample_time):
 
         integral = self.int_val + error * sample_time
-        derivative = (error - self.last_error) / sample_time
+        if self.last_error is not None:
+            derivative = (error - self.last_error) / sample_time
+        else:
+            derivative = 0.0
 
-        val = self.kp * error + self.ki * integral + self.kd * derivative
+        val = self.coeffs[0] * error + self.coeffs[1] * integral + self.coeffs[2] * derivative
 
         if val > self.max:
             val = self.max

--- a/ros/src/twist_controller/test_twiddle.py
+++ b/ros/src/twist_controller/test_twiddle.py
@@ -1,0 +1,68 @@
+import unittest
+from twiddle import Twiddle
+from pid import PID
+import random
+import math
+
+
+class TestTwiddle(unittest.TestCase):
+    def test_twiddle_inactive(self):
+        """Twiddle should behave just as the PID controller when inactive"""
+        pid = PID(kp=1.0, ki=2.0, kd=3.0)
+        twiddle = Twiddle(kp=1.0, ki=2.0, kd=3.0)
+        for i in range(1000):
+            error = random.uniform(-10.0, 10.0)
+            self.assertEqual(twiddle.step(error, 1), pid.step(error, 1))
+
+    def test_twiddle_improves_pid_controller(self):
+        twiddle = Twiddle(kp=0.01, ki=0.0001, kd=0.03, active=True)
+        lowest_error = float('inf')
+        verify_runs = [0, 500, 1000]
+        sys = TestSystem()
+
+        for i in range(1001):
+            if i not in verify_runs:
+                sys.run(twiddle)
+                twiddle.set_next_params()
+            else:
+                twiddle.abort()
+                error = sys.run(twiddle)
+                self.assertLess(error, lowest_error)
+                lowest_error = error
+                twiddle.cont()
+
+
+class TestSystem(object):
+    """Simple test system to help verify that the twiddle algorithm improves the PID controller"""
+    def __init__(self):
+        self.reset()
+
+    def reset(self):
+        """Reset system state"""
+        self.__hidden = 0.0
+        self.__target = 0.0
+        self.__actual = 0.0
+
+    def update(self, control_signal):
+        """Update system state"""
+        self.__hidden += 0.1
+        self.__target = math.sin(self.__hidden)
+        self.__actual += control_signal
+        return self.__actual - self.__target
+
+    def run(self, pid):
+        """Run a number of update steps and accumulate the error"""
+        self.reset()
+        accumulated_error = 0.0
+        control_signal = 0.0
+
+        for i in range(100):
+            error = self.update(control_signal)
+            accumulated_error += abs(error)
+            control_signal = pid.step(error, 1.0)
+
+        return accumulated_error
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ros/src/twist_controller/twiddle.py
+++ b/ros/src/twist_controller/twiddle.py
@@ -1,0 +1,155 @@
+import rospy
+import pid
+import numpy as np
+
+
+class Twiddle(pid.PID):
+
+    def __init__(self, kp, ki, kd,
+                 mn=pid.MIN_NUM, mx=pid.MAX_NUM,
+                 dkp=None, dki=None, dkd=None,
+                 active=False):
+        super(Twiddle, self).__init__(kp, ki, kd, mn, mx)
+
+        # Tuning delta for each coefficient kp, ki and kd
+        self.delta_coeffs = [dkp if dkp is not None else kp * 0.1,
+                             dki if dki is not None else ki * 0.1,
+                             dkd if dkd is not None else kd * 0.1]
+        self.coeff_idx = 0
+
+        self.active = active
+        self.lowest_error = np.inf
+        self.tuning_count = 0
+        self.state_machine = StateMachine(StateMachine.init)
+
+        self.reset()
+
+    def reset(self):
+        super(Twiddle, self).reset()
+        self.accumulated_error = 0.0
+
+    def step(self, error, sample_time):
+        """Calculate the score for the twiddle algorithm
+
+        Larger errors are punished more by taking the square.
+        Negative errors, that is when the actual value is above the target value, is punished by an extra factor of 10.
+        """
+        if error > 0.0:
+            # Actual value is below target value.
+            self.accumulated_error += (error**2.0)
+        else:
+            # Actual value is above target value.
+            self.accumulated_error += 10.0 * (error**2.0)
+        return super(Twiddle, self).step(error, sample_time)
+
+    def set_next_params(self):
+        if self.active:
+            if self.accumulated_error < self.lowest_error:
+                # This tuning is the best so far.
+                self.lowest_error = self.accumulated_error
+                rospy.loginfo("%s Improvement %s coeffs %s delta %s",
+                              self.tuning_count, self.accumulated_error, self.coeffs, self.delta_coeffs)
+
+                if isinstance(self.state_machine.state, Init):
+                    # Try a more aggressive tuning next time.
+                    self.delta_coeffs[self.coeff_idx] *= 1.1
+                    self.state_machine.state = StateMachine.increase
+            else:
+                rospy.loginfo("%s No improvement %s coeffs %s delta %s",
+                              self.tuning_count, self.accumulated_error, self.coeffs, self.delta_coeffs)
+            self.state_machine.run(self)
+            self.reset()
+
+    def abort(self):
+        """Revert ongoing tuning attempt and deactivate algorithm"""
+        self.active = False
+        if isinstance(self.state_machine.state, Revert):
+            # Ongoing decrease.
+            self.coeffs[self.coeff_idx] += self.delta_coeffs[self.coeff_idx]
+        elif isinstance(self.state_machine.state, Decrease):
+            # Ongoing increase.
+            self.coeffs[self.coeff_idx] -= self.delta_coeffs[self.coeff_idx]
+
+    def cont(self):
+        """Continue tuning"""
+        self.active = True
+        self.lowest_error = np.inf
+        self.state_machine.state = StateMachine.init
+        self.coeff_idx = 0
+
+
+class State(object):
+    """Base class for a state in the state state_machine
+
+    Derived classes must implement either also_run() or next().
+    """
+    def run(self, twiddle):
+        """Performs the action of this state"""
+        assert(False)
+
+    def also_run(self):
+        """Return other state to also be executed during this run of the state machine."""
+        return None
+
+    def next(self):
+        assert(False)
+
+
+class Revert(State):
+    def run(self, twiddle):
+        """ Revert current tuning attempt.coeff_idx
+
+        Also make next attempt with this coefficient less aggressive.
+        """
+        twiddle.coeffs[twiddle.coeff_idx] += twiddle.delta_coeffs[twiddle.coeff_idx]
+        twiddle.delta_coeffs[twiddle.coeff_idx] *= 0.9
+
+    def also_run(self):
+        return StateMachine.increase
+
+
+class Increase(State):
+    def run(self, twiddle):
+        twiddle.coeff_idx = (twiddle.coeff_idx + 1) % len(twiddle.coeffs)
+        if twiddle.coeff_idx == 0:
+            twiddle.tuning_count += 1
+        twiddle.coeffs[twiddle.coeff_idx] += twiddle.delta_coeffs[twiddle.coeff_idx]
+
+    def next(self):
+        return StateMachine.decrease
+
+
+class Init(State):
+    def run(self, twiddle):
+        twiddle.coeffs[twiddle.coeff_idx] += twiddle.delta_coeffs[twiddle.coeff_idx]
+
+    def next(self):
+        return StateMachine.decrease
+
+
+class Decrease(State):
+    def run(self, twiddle):
+        twiddle.coeffs[twiddle.coeff_idx] -= 2.0 * twiddle.delta_coeffs[twiddle.coeff_idx]
+
+    def next(self):
+        return StateMachine.revert
+
+
+class StateMachine(object):
+    def __init__(self, initial_state):
+        self.state = initial_state
+
+    def run(self, twiddle):
+        while True:
+            self.state.run(twiddle)
+            if self.state.also_run() is None:
+                break
+            self.state = self.state.also_run()
+
+        self.state = self.state.next()
+
+
+StateMachine.init = Init()
+StateMachine.increase = Increase()
+StateMachine.decrease = Decrease()
+StateMachine.revert = Revert()

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -1,7 +1,7 @@
 import rospy
 from yaw_controller import YawController
 from lowpass import LowPassFilter
-from pid import PID
+from twiddle import Twiddle
 
 GAS_DENSITY = 2.858
 ONE_MPH = 0.44704
@@ -23,7 +23,7 @@ class Controller(object):
         self.max_steer_angle = max_steer_angle
 
         self.yaw_controller = YawController(wheel_base, steer_ratio, 0.1, max_lat_accel, max_steer_angle)
-        self.throttle_controller = PID(kp=1.5, ki=0.1, kd=0.0, mn=0.0, mx=0.2)
+        self.throttle_controller = Twiddle(kp=1.5, ki=0.1, kd=0.0, mn=0.0, mx=0.2)
         self.vel_lpf = LowPassFilter(tau=0.5, ts=0.02)
         self.last_time = rospy.get_time()
 

--- a/ros/src/waypoint_updater/controller_tuning.py
+++ b/ros/src/waypoint_updater/controller_tuning.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+
+import rospy
+from std_msgs.msg import Empty, Int32
+import itertools
+import numpy as np
+from enum import Enum
+from waypoint_updater import WaypointUpdater
+
+
+class ControllerTuning(WaypointUpdater):
+
+    def __init__(self):
+        super(ControllerTuning, self).__init__()
+        self.traffic_waypoint_msg = Int32(-1)  # Traffic waypoints are disabled
+        self.set_next_tuning_pub = rospy.Publisher('/set_next_tuning', Empty, queue_size=1)
+        self.tuning = TuningSettings(self.publish_set_next_tuning)
+        self.waitUntilInit()
+        self.loopForEver()
+
+    def loopForEver(self):
+        while not rospy.is_shutdown():
+            if self.dbw_enabled_msg.data:
+                # Get current tuning settings
+                target_velocity, jerk_limit = self.tuning.get_settings(self.velocity_msg.twist.linear.x)
+
+                # Update settings in waypoint calculator
+                self.wp_calc.set_target_velocity(target_velocity)
+                self.wp_calc.set_jerk_limit(jerk_limit)
+
+                waypoints = self.wp_calc.calc_waypoints(self.pose_msg, self.velocity_msg, self.traffic_waypoint_msg)
+                self.publish_waypoints(waypoints)
+            else:
+                assert(False)  # DBW must always be active when tuning
+            self.rate.sleep()
+
+    def publish_set_next_tuning(self):
+        self.set_next_tuning_pub.publish(Empty())
+
+
+class TuningSettings(object):
+
+    def __init__(self, publish_set_next_tuning):
+        self.publish_set_next_tuning = publish_set_next_tuning
+        self.idx = 0
+        self.state = self.State.ACCELERATE
+
+        velocities = [20.0, 10.0, 5.0]
+        jerk_limits = [10.0, 7.5, 5.0, 2.5]
+        self.settings = list(itertools.product(velocities, jerk_limits))
+
+    class State(Enum):
+        ACCELERATE = 0
+        KEEP_SPEED = 1
+        DECELERATE = 2
+        STAND_STILL = 3
+
+    def get_settings(self, current_speed):
+        if self.state == self.State.ACCELERATE and np.isclose(current_speed, self.settings[self.idx][0], atol=0.5):
+            self.state = self.State.KEEP_SPEED
+            self.start_time = rospy.get_time()
+        elif self.state == self.State.KEEP_SPEED and (rospy.get_time() - self.start_time) > 5.0:
+            self.state = self.State.DECELERATE
+        elif self.state == self.State.DECELERATE and np.isclose(current_speed, 0.0, atol=0.005):
+            self.state = self.State.STAND_STILL
+            self.start_time = rospy.get_time()
+        elif self.state == self.State.STAND_STILL and (rospy.get_time() - self.start_time) > 2.0:
+            self.state = self.State.ACCELERATE
+            self.idx += 1
+            if self.idx == len(self.settings):
+                self.publish_set_next_tuning()
+                self.idx = 0
+
+        if self.state in (self.State.ACCELERATE, self.State.KEEP_SPEED):
+            target_speed = self.settings[self.idx][0]
+        else:
+            target_speed = 0.0
+
+        jerk_limit = self.settings[self.idx][1]
+
+        return target_speed, jerk_limit
+
+
+if __name__ == '__main__':
+    try:
+        ControllerTuning()
+    except rospy.ROSInterruptException:
+        rospy.logerr('Could not start waypoint updater node.')

--- a/ros/src/waypoint_updater/launch/controller_tuning.launch
+++ b/ros/src/waypoint_updater/launch/controller_tuning.launch
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<launch>
+    <node pkg="waypoint_updater" type="controller_tuning.py" name="waypoint_updater" />
+</launch>


### PR DESCRIPTION
Resolves #9 

- Implements the Twiddle algorithm for tuning of throttle PID controller. 
-- Twiddle is activated by a new parameter "tuning_active" that by default is False, in which case Twiddle acts just like a PID regulator. 
- Prepares a special version of the waypoint_updater node, 
-- that generates /final_waypoints that cycle through a sequence of accelerations and decelerations using different jerk_limits. 
-- Publish a /set_next_tuning topic to notify the Twiddle algorithm running in the twist_controller node when the acceleration sequence is done, such that twiddle can update the parameters for next iteration.
- This is implemented in a new launch configuration: ros/launch/controller_tuning.launch 
-- The TL detection is disabled in this launch configuration.