### PR TITLE
Throttle PID coefficients

### DIFF
--- a/ros/src/twist_controller/pid.py
+++ b/ros/src/twist_controller/pid.py
@@ -4,8 +4,8 @@ MAX_NUM = float('inf')
 
 
 class PID(object):
-    def __init__(self, kp, ki, kd, mn=MIN_NUM, mx=MAX_NUM):
-        self.coeffs = [kp, ki, kd]
+    def __init__(self, coeffs, mn=MIN_NUM, mx=MAX_NUM):
+        self.coeffs = coeffs
         self.min = mn
         self.max = mx
 

--- a/ros/src/twist_controller/test_twiddle.py
+++ b/ros/src/twist_controller/test_twiddle.py
@@ -8,14 +8,14 @@ import math
 class TestTwiddle(unittest.TestCase):
     def test_twiddle_inactive(self):
         """Twiddle should behave just as the PID controller when inactive"""
-        pid = PID(kp=1.0, ki=2.0, kd=3.0)
-        twiddle = Twiddle(kp=1.0, ki=2.0, kd=3.0)
+        pid = PID(coeffs=[1.0, 2.0, 3.0])
+        twiddle = Twiddle(coeffs=[1.0, 2.0, 3.0])
         for i in range(1000):
             error = random.uniform(-10.0, 10.0)
             self.assertEqual(twiddle.step(error, 1), pid.step(error, 1))
 
     def test_twiddle_improves_pid_controller(self):
-        twiddle = Twiddle(kp=0.01, ki=0.0001, kd=0.03, active=True)
+        twiddle = Twiddle(coeffs=[0.01, 0.0001, 0.03], active=True)
         lowest_error = float('inf')
         verify_runs = [0, 500, 1000]
         sys = TestSystem()

--- a/ros/src/twist_controller/twiddle.py
+++ b/ros/src/twist_controller/twiddle.py
@@ -5,18 +5,15 @@ import numpy as np
 
 class Twiddle(pid.PID):
 
-    def __init__(self, kp, ki, kd,
+    def __init__(self, coeffs,
                  mn=pid.MIN_NUM, mx=pid.MAX_NUM,
-                 dkp=None, dki=None, dkd=None,
+                 delta_coeffs=None,
                  active=False):
-        super(Twiddle, self).__init__(kp, ki, kd, mn, mx)
+        super(Twiddle, self).__init__(coeffs, mn, mx)
 
-        # Tuning delta for each coefficient kp, ki and kd
-        self.delta_coeffs = [dkp if dkp is not None else kp * 0.1,
-                             dki if dki is not None else ki * 0.1,
-                             dkd if dkd is not None else kd * 0.1]
+        # Tuning delta for each coefficient
+        self.delta_coeffs = delta_coeffs if delta_coeffs is not None else [coeff * 0.1 for coeff in coeffs]
         self.coeff_idx = 0
-
         self.active = active
         self.lowest_error = np.inf
         self.tuning_count = 0

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -24,12 +24,11 @@ class Controller(object):
 
         self.yaw_controller = YawController(wheel_base, steer_ratio, 0.1, max_lat_accel, max_steer_angle)
 
-        coeffs = [1.0, 0.0, 0.0]  # PID controller coefficients
-        delta = [0.1, 0.01, 0.01]  # Delta values for tuning of PID coefficients, used by Twiddle algorithm.
         # When parameter tuning_active is false, then Twiddle behaves just like a PID controller.
-        self.throttle_controller = Twiddle(kp=coeffs[0], ki=coeffs[1], kd=coeffs[2],
-                                           dkp=delta[0], dki=delta[1], dkd=delta[2],
-                                           mn=0.0, mx=1.0, active=tuning_active)
+        self.throttle_controller = Twiddle(
+            coeffs=[1.1999999999999993, -0.021952551922336052, -0.003874204890000004],
+            delta_coeffs=[0.004031356972346669, 0.00041132098483284045, 0.0002503155504993245],
+            mn=0.0, mx=1.0, active=tuning_active)
         self.vel_lpf = LowPassFilter(tau=0.5, ts=0.02)
         self.last_time = rospy.get_time()
 


### PR DESCRIPTION
Resolves #10 

The Twiddle algorithm was running for about 24 hours and these
coefficients gave the best score.

The result from running a few tuning cycles with the same
coefficients does however actually give quite large variance to the
twiddle scores. I guess extraneous factors from running in the
simulator actually have larger impact on the twiddle score than the
changes made to the coefficients. So in order to improve the
coefficients further, a better measurement for the score is needed,
maybe by taking the average over several tuning cycles.