### PR TITLE
Throttle tuning without kI

### DIFF
--- a/ros/src/twist_controller/twiddle.py
+++ b/ros/src/twist_controller/twiddle.py
@@ -29,14 +29,14 @@ class Twiddle(pid.PID):
         """Calculate the score for the twiddle algorithm
 
         Larger errors are punished more by taking the square.
-        Negative errors, that is when the actual value is above the target value, is punished by an extra factor of 10.
+        Negative errors, that is when the actual value is above the target value, is punished by an extra factor of 2.
         """
         if error > 0.0:
             # Actual value is below target value.
             self.accumulated_error += (error**2.0)
         else:
             # Actual value is above target value.
-            self.accumulated_error += 10.0 * (error**2.0)
+            self.accumulated_error += 2.0 * (error**2.0)
         return super(Twiddle, self).step(error, sample_time)
 
     def set_next_params(self):

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -23,11 +23,10 @@ class Controller(object):
         self.max_steer_angle = max_steer_angle
 
         self.yaw_controller = YawController(wheel_base, steer_ratio, 0.1, max_lat_accel, max_steer_angle)
-
         # When parameter tuning_active is false, then Twiddle behaves just like a PID controller.
         self.throttle_controller = Twiddle(
-            coeffs=[1.1999999999999993, 0.0, -0.003874204890000004],
-            delta_coeffs=[0.004031356972346669, 0.0, 0.0002503155504993245],
+            coeffs=[1.2039910434026229, 0.0, -0.0035236404646812065],
+            delta_coeffs=[0.0035204594750199024, 0.0, 0.00014780882941434616],
             mn=0.0, mx=1.0, active=tuning_active)
         self.vel_lpf = LowPassFilter(tau=0.5, ts=0.02)
         self.last_time = rospy.get_time()

--- a/ros/src/waypoint_updater/controller_tuning.py
+++ b/ros/src/waypoint_updater/controller_tuning.py
@@ -59,12 +59,12 @@ class TuningSettings(object):
         if self.state == self.State.ACCELERATE and np.isclose(current_speed, self.settings[self.idx][0], atol=0.5):
             self.state = self.State.KEEP_SPEED
             self.start_time = rospy.get_time()
-        elif self.state == self.State.KEEP_SPEED and (rospy.get_time() - self.start_time) > 5.0:
+        elif self.state == self.State.KEEP_SPEED and (rospy.get_time() - self.start_time) > 20.0:
             self.state = self.State.DECELERATE
         elif self.state == self.State.DECELERATE and np.isclose(current_speed, 0.0, atol=0.005):
             self.state = self.State.STAND_STILL
             self.start_time = rospy.get_time()
-        elif self.state == self.State.STAND_STILL and (rospy.get_time() - self.start_time) > 2.0:
+        elif self.state == self.State.STAND_STILL and (rospy.get_time() - self.start_time) > 5.0:
             self.state = self.State.ACCELERATE
             self.idx += 1
             if self.idx == len(self.settings):


### PR DESCRIPTION
Repeat the throttle tuning by
- Skipping the integral coefficient in the PID controller.
- Increase the number of seconds the vehicle should keep the target
  speed from 5 to 20 to make this more important.
- Increase the number of seconds the vehicle should be stopped from 2
  to 5.
- Decrease the extra punishment factor on exceeding target speed in
  the twiddle algorithm from 10 to 2. There is now extra safety
  margin implemented elsewhere which makes this less important.