### PR TITLE
No deepcopy in waypoint updater

### DIFF
--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -159,8 +159,7 @@ class WaypointCalculator(object):
             # Copy the preceding waypoint before updating the waypoint list.
             self.preceding_waypoint = self.waypoints[(first_idx - self.previous_first_idx - 1) %
                                                      len(self.base_waypoints_msg.waypoints)]
-
-        self.waypoints = deepcopy(self.base_waypoints_msg.waypoints[first_idx:first_idx + LOOKAHEAD_WPS])
+        self.waypoints = self.base_waypoints_msg.waypoints[first_idx:first_idx + LOOKAHEAD_WPS]
         self.previous_first_idx = first_idx
 
         # Calculate the final_waypoints


### PR DESCRIPTION
The waypoint_updater copies 200 base_waypoints and use this as a
starting point for the final_waypoints. This copy is implemented as a
deepcopy, which consumes an surprisingly large amount of CPU time,
e.g. around 100 ms on the Udacity workspace. The deepcopy is however
no longer needed as the target velocity is calculated from the
base_waypoints during initialization, and the velocity for all
final_waypoints are explicitly modified for each update. A shallow
copy takes almost no time, so this solves the problem.